### PR TITLE
feat(spark-connector): 添加ScalaTest依赖并更新ODPS SDK版本

### DIFF
--- a/spark-connector/common/pom.xml
+++ b/spark-connector/common/pom.xml
@@ -142,6 +142,12 @@
             <version>1.15.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-funsuite_${scala.binary.version}</artifactId>
+            <version>3.2.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
+++ b/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
@@ -15,23 +15,17 @@ object ExecutionUtils {
   }
 
   private def convertToOdpsPredicate(filter: Filter): Predicate = filter match {
-    case AlwaysTrue() => Predicate.NO_PREDICATE
-    case AlwaysFalse() => RawPredicate.of("true = false")
-    case EqualTo(attribute, value) => BinaryPredicate.equals(Attribute(attribute), Constant.of(value))
-    case GreaterThan(attribute, value) => BinaryPredicate.greaterThan(Attribute(attribute), Constant.of(value))
-    case GreaterThanOrEqual(attribute, value) => BinaryPredicate.greaterThanOrEqual(Attribute(attribute), Constant.of(value))
-    case LessThan(attribute, value) => BinaryPredicate.lessThan(Attribute(attribute), Constant.of(value))
-    case LessThanOrEqual(attribute, value) => BinaryPredicate.lessThanOrEqual(Attribute(attribute), Constant.of(value))
-    case In(attribute, values) => InPredicate.in(Attribute(attribute), values.map(Constant.of).toList.asJava.asInstanceOf[java.util.List[java.io.Serializable]])
-    case IsNull(attribute) => UnaryPredicate.isNull(Attribute(attribute))
-    case IsNotNull(attribute) => UnaryPredicate.notNull(Attribute(attribute))
+    case EqualTo(attribute, value) => BinaryPredicate.equals(Attribute.of(attribute), Constant.of(value))
+    case GreaterThan(attribute, value) => BinaryPredicate.greaterThan(Attribute.of(attribute), Constant.of(value))
+    case GreaterThanOrEqual(attribute, value) => BinaryPredicate.greaterThanOrEqual(Attribute.of(attribute), Constant.of(value))
+    case LessThan(attribute, value) => BinaryPredicate.lessThan(Attribute.of(attribute), Constant.of(value))
+    case LessThanOrEqual(attribute, value) => BinaryPredicate.lessThanOrEqual(Attribute.of(attribute), Constant.of(value))
+    case In(attribute, values) => InPredicate.in(Attribute.of(attribute), values.map(Constant.of).toList.asJava.asInstanceOf[java.util.List[java.io.Serializable]])
+    case IsNull(attribute) => UnaryPredicate.isNull(Attribute.of(attribute))
+    case IsNotNull(attribute) => UnaryPredicate.notNull(Attribute.of(attribute))
     case And(left, right) => CompoundPredicate.and(convertToOdpsPredicate(left), convertToOdpsPredicate(right))
     case Or(left, right) => CompoundPredicate.or(convertToOdpsPredicate(left), convertToOdpsPredicate(right))
     case Not(child) => CompoundPredicate.not(convertToOdpsPredicate(child))
     case _ => Predicate.NO_PREDICATE
-  }
-
-  private def Attribute(str: String): String = {
-    "`" + str + "`";
   }
 }

--- a/spark-connector/common/src/test/scala/org/apache/spark/sql/odps/ExecutionUtilsSuite.scala
+++ b/spark-connector/common/src/test/scala/org/apache/spark/sql/odps/ExecutionUtilsSuite.scala
@@ -1,0 +1,102 @@
+package org.apache.spark.sql.odps
+
+import org.apache.spark.sql.sources.{And, StringStartsWith, _}
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExecutionUtilsSuite extends AnyFunSuite {
+
+  test("convertToOdpsPredicate should return NO_PREDICATE for an empty filter sequence") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq.empty[Filter])
+    assert(result.toString === "")
+  }
+
+  test("convertToOdpsPredicate should convert AlwaysTrue to NO_PREDICATE") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(AlwaysTrue()))
+    assert(result.toString === "")
+  }
+
+  test("convertToOdpsPredicate should convert AlwaysFalse to NO_PREDICATE") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(AlwaysFalse()))
+    assert(result.toString === "")
+  }
+
+  test("convertToOdpsPredicate should convert EqualTo correctly") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(EqualTo("column1", 42)))
+    assert(result.toString === "`column1` = 42")
+  }
+
+  test("convertToOdpsPredicate should convert GreaterThan correctly") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(GreaterThan("column1", 10)))
+    assert(result.toString === "`column1` > 10")
+  }
+
+  test("convertToOdpsPredicate should handle AND conditions correctly") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(And(EqualTo("column1", 42), GreaterThan("column2", 10))))
+    assert(result.toString === "`column1` = 42 and `column2` > 10")
+  }
+
+  test("convertToOdpsPredicate should handle OR conditions correctly") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(Or(EqualTo("column1", 42), LessThan("column2", 10))))
+    assert(result.toString === "(`column1` = 42 or `column2` < 10)")
+  }
+
+  test("convertToOdpsPredicate should combine predicates correctly") {
+    val filters = Seq(
+      EqualTo("column1", "value"),
+      GreaterThan("column2", 10),
+      IsNotNull("column3")
+    )
+    val result = ExecutionUtils.convertToOdpsPredicate(filters)
+    assert(result.toString === "`column1` = 'value' and `column2` > 10 and `column3` is not null")
+  }
+
+  test("convertToOdpsPredicate should handle NOT conditions correctly") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(Not(IsNull("column1"))))
+    assert(result.toString === "(not `column1` is null)")
+  }
+
+
+  test("convertToOdpsPredicate should handle complex nested conditions correctly") {
+    val filters = Seq(
+      And(
+        Or(EqualTo("column1", "value"), StringStartsWith("column1", "pattern")),
+        And(GreaterThan("column2", 10), IsNotNull("column3"))
+      ),
+      StringStartsWith("column1", "pattern2"),
+      Or(GreaterThan("column3", 10), IsNotNull("column4"))
+    )
+
+    val result = ExecutionUtils.convertToOdpsPredicate(filters)
+
+    assert(result.toString === "`column2` > 10 and `column3` is not null and (`column3` > 10 or `column4` is not null)")
+  }
+
+  test("convertToOdpsPredicate should handle multiple IsNull conditions correctly") {
+    val filters = Seq(IsNull("column1"), IsNull("column2"))
+    val result = ExecutionUtils.convertToOdpsPredicate(filters)
+    assert(result.toString === "`column1` is null and `column2` is null")
+  }
+
+  test("convertToOdpsPredicate cannot convert StringContains") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(StringContains("column1", "subString")))
+    assert(result.toString === "")
+  }
+
+  test("convertToOdpsPredicate cannot convert StringEndsWith") {
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(StringEndsWith("column1", "suffix")))
+    assert(result.toString === "")
+  }
+
+  test("convertToOdpsPredicate should handle deeply nested conditions correctly") {
+    val filters = Seq(
+      Or(
+        And(EqualTo("column1", "value1"), GreaterThan("column2", 10)),
+        And(EqualTo("column1", "value2"), LessThan("column3", 5)),
+      )
+    )
+    val result = ExecutionUtils.convertToOdpsPredicate(filters)
+    assert(result.toString === "((`column1` = 'value1' and `column2` > 10) or (`column1` = 'value2' and `column3` < 5))")
+  }
+
+}
+

--- a/spark-connector/pom.xml
+++ b/spark-connector/pom.xml
@@ -21,8 +21,8 @@
     <packaging>pom</packaging>
     <properties>
         <arrow.version>4.0.0</arrow.version>
-        <odps.sdk.version>0.48.7-public</odps.sdk.version>
-        <odps.sdk.table.version>0.48.7-public</odps.sdk.table.version>
+        <odps.sdk.version>0.48.8-public</odps.sdk.version>
+        <odps.sdk.table.version>0.48.8-public</odps.sdk.table.version>
         <spark.version>3.3.1</spark.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
* 更新`pom.xml`中的ODPS SDK版本至0.48.8-public
* 引入ScalaTest依赖以增强测试框架支持
* 创建`ExecutionUtilsSuite.scala`用于执行单元测试
* 修改`ExecutionUtils.scala`中的`convertToOdpsPredicate`方法参数处理方式