### PR TITLE
fix(Predicate): 避免对引用类型发生double quote

### DIFF
--- a/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
+++ b/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
@@ -139,9 +139,11 @@ object ExecutionUtils {
       throw new UnsupportedOperationException(s"Unsupported filter: $filter")
   }
 
-  // when set nestedPredicatePushdownEnabled=true, Attribute will quoteIfNeeded, so here determine whether the attribute has already been quoted
-  // {@see org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper.quoted}
-  // {@see org.apache.spark.sql.catalyst.util#quoteIfNeeded}
+  /**
+   * when spark call [[DataSourceStrategy.translateFilter]],
+   * all Attribute will quote by [[org.apache.spark.sql.catalyst.util#quoteIfNeeded]],
+   * so here we need to determine whether the attribute has already been quoted
+   */
   private def quoteAttribute(value: String): String = {
     if (value.startsWith("`") && value.endsWith("`") && value.length() > 1) {
       value

--- a/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
+++ b/spark-connector/common/src/main/scala/org/apache/spark/sql/odps/ExecutionUtils.scala
@@ -144,8 +144,9 @@ object ExecutionUtils {
   // {@see org.apache.spark.sql.catalyst.util#quoteIfNeeded}
   private def quoteAttribute(value: String): String = {
     if (value.startsWith("`") && value.endsWith("`") && value.length() > 1) {
-      return value;
+      value
+    } else {
+      s"`${value.replace("`", "``")}`"
     }
-    "`" + value + "`";
   }
 }

--- a/spark-connector/common/src/test/scala/org/apache/spark/sql/odps/ExecutionUtilsSuite.scala
+++ b/spark-connector/common/src/test/scala/org/apache/spark/sql/odps/ExecutionUtilsSuite.scala
@@ -136,5 +136,19 @@ class ExecutionUtilsSuite extends AnyFunSuite {
 
     assert(result.toString === "(`column3` > 10 or `column4` is not null)")
   }
+
+  test("QuoteChines") {
+    val greaterThan = GreaterThan("`你好`", 2)
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(greaterThan))
+    println(result.toString)
+    assert(result.toString == "`你好` > 2")
+  }
+
+  test("QuoteSpecialCharacter") {
+    val greaterThan = GreaterThan("你`好", 2)
+    val result = ExecutionUtils.convertToOdpsPredicate(Seq(greaterThan))
+    println(result.toString)
+    assert(result.toString == "`你``好` > 2")
+  }
 }
 


### PR DESCRIPTION
在 `convertToOdpsPredicate` 方法中添加了对属性名进行引用处理的功能，确保属性名被正确地包围在反引号(`)内。增加了新的私有方法 `quoteAttribute` 来实现这一功能。